### PR TITLE
Fix logic to get changelog from last tag

### DIFF
--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/git/GitRepository.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/git/GitRepository.kt
@@ -11,13 +11,12 @@ internal class GitRepository(
     /**
      * Finds a range of build tags, returning `null` if no build tags are present (happens on a new projects)
      */
-    fun findBuildTags(buildType: String): TagRange? {
-        val tags = commandExecutor.findBuildTags(buildType, limitResultCount = 2)
+    fun findBuildTags(buildVariant: String): TagRange? {
+        val tags = commandExecutor.findBuildTags(buildVariant, limitResultCount = 2)
         return if (tags != null) {
             val currentBuildTag = tags.first()
             val previousBuildTag = tags.getOrNull(1)
             TagRange(
-                // todo add Build types
                 currentBuildTag = Tag.Build(currentBuildTag, buildVariants),
                 previousBuildTag = previousBuildTag?.let { Tag.Build(it, buildVariants) }
             )
@@ -25,7 +24,8 @@ internal class GitRepository(
     }
 
     fun findMostRecentBuildTag(): Tag.Build? {
-        val tags = commandExecutor.findBuildTags(buildVariants, limitResultCount = 1)
-        return tags?.first()?.let { Tag.Build(it, buildVariants) }
+        return commandExecutor
+            .findLastBuildTag(buildVariants)
+            ?.let { Tag.Build(it, buildVariants) }
     }
 }

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/git/entity/Tag.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/git/entity/Tag.kt
@@ -19,14 +19,14 @@ sealed class Tag {
         override val name: String,
         override val commitSha: String,
         override val message: String?,
-        val buildType: String,
+        val buildVariant: String,
         val buildNumber: Int
     ) : Tag() {
         constructor(tag: Tag, buildVariants: Set<String>) : this(
             tag.name,
             tag.commitSha,
             tag.message,
-            buildType = buildVariants.first { tag.name.contains(it) },
+            buildVariant = buildVariants.first { tag.name.contains(it) },
             buildNumber = Regex("\\d+").findAll(tag.name).last().value.toInt()
         )
     }

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/SendChangelogTask.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/SendChangelogTask.kt
@@ -97,12 +97,12 @@ abstract class SendChangelogTask : DefaultTask() {
 
     @TaskAction
     fun prepareTgChangelog() {
-        val buildVariants = buildVariants.get()
-        val buildTag = getBuildTag(buildVariants)
+        val allBuildVariants = buildVariants.get()
+        val buildTag = getBuildTag(allBuildVariants)
 
-        sendTelegramChangelog(buildVariants, buildTag)
-        sendSlackMessage(buildVariants, buildTag)
-        sendLocalChangelog(buildVariants)
+        sendTelegramChangelog(allBuildVariants, buildTag)
+        sendSlackMessage(allBuildVariants, buildTag)
+        sendLocalChangelog(allBuildVariants)
     }
 
     private fun sendLocalChangelog(buildVariants: Set<String>) {

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/util/Changelog.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/util/Changelog.kt
@@ -15,11 +15,11 @@ internal class Changelog(
     @Suppress("ReturnCount")
     fun buildForRecentBuildTag(defaultValueSupplier: ((TagRange) -> String?)? = null): String? {
         val gitRepository = GitRepository(commandExecutor, buildVariants)
-        val buildType = gitRepository.findMostRecentBuildTag()?.buildType
-            .also { if (it == null) logger.warn("failed to build a changelog: no recent build tag") }
+        val buildVariant = gitRepository.findMostRecentBuildTag()?.buildVariant
+            .also { if (it == null) logger.warn("failed to build a changelog: no recent variant tag") }
             ?: return null
-        val tagRange = gitRepository.findBuildTags(buildType)
-            .also { if (it == null) logger.warn("failed to build a changelog: no build tags") }
+        val tagRange = gitRepository.findBuildTags(buildVariant)
+            .also { if (it == null) logger.warn("failed to build a changelog: no variant tags") }
             ?: return null
         return build(tagRange) ?: defaultValueSupplier?.invoke(tagRange)
     }


### PR DESCRIPTION
<!-- Thanks for taking the time to write this Pull Request ❤️ -->

## 🚀 Description
Replace logic to get last tag: now takes tag without sorting by build number