### PR TITLE
Set custom AppCenter names

### DIFF
--- a/example/app/build.gradle.kts
+++ b/example/app/build.gradle.kts
@@ -79,7 +79,21 @@ buildPublish {
     }
     appCenterDistribution {
         register("default") {
-            appNamePrefix.set("Android")
+            appName.set("Android")
+            ownerName.set("android-team-kode.ru")
+            apiTokenFile.set(File("appcenter-token.txt"))
+            testerGroups.set(setOf("Collaborators"))
+        }
+
+        register("debug") {
+            appName.set("AndroidDebug")
+            ownerName.set("android-team-kode.ru")
+            apiTokenFile.set(File("appcenter-token.txt"))
+            testerGroups.set(setOf("Collaborators"))
+        }
+
+        register("release") {
+            appName.set("AndroidRelease")
             ownerName.set("android-team-kode.ru")
             apiTokenFile.set(File("appcenter-token.txt"))
             testerGroups.set(setOf("Collaborators"))

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/BuildPublishPlugin.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/BuildPublishPlugin.kt
@@ -160,13 +160,15 @@ abstract class BuildPublishPlugin : Plugin<Project> {
                 findByName(buildVariant.name) ?: findByName("default")
             }
             if (appCenterDistributionConfig != null) {
-                tasks.registerAppCenterDistributionTask(
-                    appCenterDistributionConfig,
-                    buildVariant,
-                    generateChangelogFileProvider,
-                    outputFileProvider,
-                    tagBuildProvider,
+                val params = AppCenterDistributionTaskParams(
+                    config = appCenterDistributionConfig,
+                    buildVariant = buildVariant,
+                    changelogFileProvider = generateChangelogFileProvider,
+                    buildVariantOutputFileProvider = outputFileProvider,
+                    tagBuildProvider = tagBuildProvider,
+                    outputConfig = outputConfig,
                 )
+                tasks.registerAppCenterDistributionTask(params)
             }
             val jiraConfig = with(buildPublishExtension.jira) {
                 findByName(buildVariant.name) ?: findByName("default")
@@ -358,22 +360,22 @@ abstract class BuildPublishPlugin : Plugin<Project> {
     }
 
     private fun TaskContainer.registerAppCenterDistributionTask(
-        config: AppCenterDistributionConfig,
-        buildVariant: BuildVariant,
-        changelogFileProvider: Provider<RegularFile>,
-        buildVariantOutputFileProvider: Provider<RegularFile>,
-        tagBuildProvider: Provider<RegularFile>,
+        params: AppCenterDistributionTaskParams,
     ): TaskProvider<AppCenterDistributionTask> {
+        val buildVariant = params.buildVariant
+        val config = params.config
+
         return register(
             "$APP_CENTER_DISTRIBUTION_UPLOAD_TASK_PREFIX${buildVariant.capitalizedName()}",
             AppCenterDistributionTask::class.java,
         ) {
-            it.tagBuildFile.set(tagBuildProvider)
-            it.buildVariantOutputFile.set(buildVariantOutputFileProvider)
-            it.changelogFile.set(changelogFileProvider)
+            it.tagBuildFile.set(params.tagBuildProvider)
+            it.buildVariantOutputFile.set(params.buildVariantOutputFileProvider)
+            it.changelogFile.set(params.changelogFileProvider)
             it.apiTokenFile.set(config.apiTokenFile)
             it.ownerName.set(config.ownerName)
-            it.appNamePrefix.set(config.appNamePrefix)
+            it.appName.set(config.appName)
+            it.baseFileName.set(params.outputConfig.baseFileName)
             it.testerGroups.set(config.testerGroups)
             it.maxRequestCount.set(config.maxRequestCount)
             it.requestDelayMs.set(config.requestDelayMs)
@@ -459,6 +461,15 @@ private data class OutputProviders(
     val versionName: Provider<String>,
     val versionCode: Provider<Int>,
     val outputFileName: Provider<String>,
+)
+
+private data class AppCenterDistributionTaskParams(
+    val config: AppCenterDistributionConfig,
+    val buildVariant: BuildVariant,
+    val changelogFileProvider: Provider<RegularFile>,
+    val buildVariantOutputFileProvider: Provider<RegularFile>,
+    val tagBuildProvider: Provider<RegularFile>,
+    val outputConfig: OutputConfig,
 )
 
 private fun mapToVersionCode(tagBuildFile: RegularFile): Int {

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/extension/config/AppCenterDistributionConfig.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/extension/config/AppCenterDistributionConfig.kt
@@ -23,10 +23,11 @@ interface AppCenterDistributionConfig {
     val ownerName: Property<String>
 
     /**
-     * Short app name to be used as first part of app name in the AppCenter
+     * "Application name in AppCenter. If appName isn't set plugin uses <baseFileName>-<variantName>,
+     * for example example-base-project-android-debug, example-base-project-android-internal"
      */
     @get:Input
-    val appNamePrefix: Property<String>
+    val appName: Property<String>
 
     /**
      * Test groups for app distribution


### PR DESCRIPTION
ISSUE: https://github.com/appKODE/build-publish-plugin/issues/13

## 🚀 Description
In AppCenterDistributionConfig added appName property instead of appNamePrefix. Using appName developers can upload builds with different flavors and build types into single AppCenter application