### PR TITLE
Correctly detect latest build number 

### DIFF
--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/command/GitCommandExecutor.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/command/GitCommandExecutor.kt
@@ -23,16 +23,13 @@ internal class GitCommandExecutor(
     }
 
     /**
-     * Runs git to find information about tags of a set of [buildVariants].
+     * Runs git to find information about tags of the [buildVariant].
      * Resulting set will be limited to [limitResultCount] tags or `null` if no tags found
      */
-    fun findBuildTags(buildVariants: Set<String>, limitResultCount: Int): List<Tag>? {
-        val buildTagRegex = Regex(".+\\.(\\d+)-(${buildVariants.joinToString("|")})")
+    fun findBuildTags(buildVariant: String, limitResultCount: Int): List<Tag>? {
+        val buildTagRegex = Regex(".+\\.(\\d+)-$buildVariant")
         return grgitService.grgit.tag.list()
-            .filter { tag ->
-                buildTagRegex.find(tag.name)?.groupValues?.get(1)?.let { System.err.println(it) }
-                tag.name.matches(buildTagRegex)
-            }
+            .filter { tag -> tag.name.matches(buildTagRegex) }
             .sortedBy { tag ->
                 buildTagRegex.find(tag.name)?.groupValues?.get(1)?.toIntOrNull()
                     ?: error("internal error: failed to parse build number for tag ${tag.name}")

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/enity/Tag.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/enity/Tag.kt
@@ -25,22 +25,23 @@ sealed class Tag {
         val buildVariant: String,
         val buildNumber: Int
     ) : Tag() {
-        constructor(tag: Tag, buildVariants: Set<String>) : this(
+        constructor(tag: Tag, buildVariant: String) : this(
             tag.name,
             tag.commitSha,
             tag.message,
             buildVersion = tag.toBuildVersion(),
-            buildVariant = tag.toBuildVariant(buildVariants),
+            buildVariant = tag.toBuildVariant(buildVariant),
             buildNumber = tag.toBuildNumber()
         )
     }
 }
 
-private fun Tag.toBuildVariant(buildVariants: Set<String>): String {
-    return buildVariants.firstOrNull { this.name.contains(it) }
-        ?: throw GradleException(
-            "No buildVariants for ${this.name}. Available variants: $buildVariants",
+private fun Tag.toBuildVariant(buildVariant: String): String {
+    return if (this.name.contains(buildVariant)) buildVariant else {
+        throw GradleException(
+            "No buildVariant for ${this.name}. Available variants: $buildVariant",
         )
+    }
 }
 
 private fun Tag.toBuildVersion(): String {

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/changelog/git/GitRepository.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/changelog/git/GitRepository.kt
@@ -6,26 +6,26 @@ import ru.kode.android.build.publish.plugin.enity.TagRange
 
 internal class GitRepository(
     private val gitCommandExecutor: GitCommandExecutor,
-    private val buildVariants: Set<String>,
+    private val buildVariant: String,
 ) {
     /**
      * Finds a range of build tags, returning `null` if no build tags are present (happens on a new projects)
      */
     fun findTagRange(buildVariant: String): TagRange? {
-        val tags = gitCommandExecutor.findBuildTags(setOf(buildVariant), limitResultCount = 2)
+        val tags = gitCommandExecutor.findBuildTags(buildVariant, limitResultCount = 2)
         return if (tags != null) {
             val currentBuildTag = tags.first()
             val previousBuildTag = tags.getOrNull(1)
             TagRange(
                 // todo add Build types
-                currentBuildTag = Tag.Build(currentBuildTag, buildVariants),
-                previousBuildTag = previousBuildTag?.let { Tag.Build(it, buildVariants) }
+                currentBuildTag = Tag.Build(currentBuildTag, buildVariant),
+                previousBuildTag = previousBuildTag?.let { Tag.Build(it, buildVariant) }
             )
         } else null
     }
 
     fun findRecentBuildTag(): Tag.Build? {
-        val tags = gitCommandExecutor.findBuildTags(buildVariants, limitResultCount = 1)
-        return tags?.first()?.let { Tag.Build(it, buildVariants) }
+        val tags = gitCommandExecutor.findBuildTags(buildVariant, limitResultCount = 1)
+        return tags?.first()?.let { Tag.Build(it, buildVariant) }
     }
 }

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/changelog/work/GenerateChangelogWork.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/changelog/work/GenerateChangelogWork.kt
@@ -28,9 +28,9 @@ abstract class GenerateChangelogWork @Inject constructor() : WorkAction<Generate
     override fun execute() {
         val messageKey = parameters.commitMessageKey.get()
         val currentBuildTag = fromJson(parameters.tagBuildFile.asFile.get())
-        val buildVariants = setOf(parameters.buildVariant.get())
+        val buildVariant = parameters.buildVariant.get()
         val gitCommandExecutor = GitCommandExecutor(parameters.grgitService.get())
-        val gitRepository = GitRepository(gitCommandExecutor, buildVariants)
+        val gitRepository = GitRepository(gitCommandExecutor, buildVariant)
         val changelog = ChangelogBuilder(gitRepository, gitCommandExecutor, logger, messageKey)
             .buildForBuildTag(
                 currentBuildTag,

--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/tag/work/GenerateTagWork.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/tag/work/GenerateTagWork.kt
@@ -22,9 +22,9 @@ abstract class GenerateTagWork @Inject constructor() : WorkAction<GenerateTagPar
     private val logger = Logging.getLogger(this::class.java)
 
     override fun execute() {
-        val buildVariants = setOf(parameters.buildVariant.get())
+        val buildVariant = parameters.buildVariant.get()
         val gitCommandExecutor = GitCommandExecutor(parameters.grgitService.get())
-        val buildTag = GitRepository(gitCommandExecutor, buildVariants).findRecentBuildTag()
+        val buildTag = GitRepository(gitCommandExecutor, buildVariant).findRecentBuildTag()
         val tagBuildOutput = parameters.tagBuildFile.asFile.get()
 
         if (buildTag != null) {


### PR DESCRIPTION
This is required because git sorts tags lexicographically causing this
order for example:

v1.0.10
v1.0.9 <- without soring this would be the last tag

which leads to incorrect last tag matching.