### PR TITLE
[AppCenter] Add a maximum character limit for notes app center

### DIFF
--- a/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/appcenter/work/AppCenterUploadWork.kt
+++ b/plugin-build/plugin/src/main/java/ru/kode/android/build/publish/plugin/task/appcenter/work/AppCenterUploadWork.kt
@@ -10,6 +10,7 @@ import ru.kode.android.build.publish.plugin.extension.config.MAX_REQUEST_COUNT
 import ru.kode.android.build.publish.plugin.extension.config.MAX_REQUEST_DELAY_MS
 import ru.kode.android.build.publish.plugin.task.appcenter.entity.ChunkRequestBody
 import ru.kode.android.build.publish.plugin.task.appcenter.uploader.AppCenterUploader
+import ru.kode.android.build.publish.plugin.util.ellipsizeAt
 import kotlin.math.round
 
 interface AppCenterUploadParameters : WorkParameters {
@@ -87,7 +88,11 @@ abstract class AppCenterUploadWork : WorkAction<AppCenterUploadParameters> {
         logger.info("Step 7/7: Distribute to the app testers: $testerGroups")
         val releaseId = publishResponse.release_distinct_id
         if (releaseId != null) {
-            uploader.distribute(releaseId, testerGroups, changelogFile.readText())
+            uploader.distribute(
+                releaseId = releaseId,
+                distributionGroups = testerGroups,
+                releaseNotes = changelogFile.readText().ellipsizeAt(MAX_NOTES_CHARACTERS_COUNT),
+            )
         } else {
             logger.error(
                 "Apk was uploaded, " +
@@ -118,3 +123,4 @@ private fun Long.bytesToMegabytes(): Double {
 
 private const val BYTES_PER_MEGABYTE = 1024.0 * 1024.0
 private const val MILLIS_IN_SEC = 1000
+private const val MAX_NOTES_CHARACTERS_COUNT = 5000


### PR DESCRIPTION
When the changelog file is large, publishing to app center fails with an error:  “The release notes exceeds the limit of 5000 characters”. To fix this problem, forcibly limit the maximum length of attached release notes

ISSUE: https://github.com/appKODE/build-publish-plugin/issues/53
